### PR TITLE
Add py-log-symbols to the Related section in the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,7 @@ console.log(logSymbols.success, 'Finished successfully!');
 ## Related
 
 - [figures](https://github.com/sindresorhus/figures) - Unicode symbols with Windows CMD fallbacks
+- [py-log-symbols](https://github.com/ManrajGrover/py-log-symbols) - Colored symbols for various log levels for Python
 
 
 ## License

--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,7 @@ console.log(logSymbols.success, 'Finished successfully!');
 ## Related
 
 - [figures](https://github.com/sindresorhus/figures) - Unicode symbols with Windows CMD fallbacks
-- [py-log-symbols](https://github.com/ManrajGrover/py-log-symbols) - Colored symbols for various log levels for Python
+- [py-log-symbols](https://github.com/ManrajGrover/py-log-symbols) - Python port
 
 
 ## License


### PR DESCRIPTION
This PR adds `py-log-symbols` to `Related` section. Thanks for being the inspiration for this package. 😸