### PR TITLE
Improve Windows support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 const chalk = require('chalk');
 
-const isSupported = process.platform !== 'win32' || process.env.CI || process.env.VSCODE_PID;
+const isSupported = process.platform !== 'win32' || process.env.CI || process.env.TERM === 'xterm-256color';
 
 const main = {
 	info: chalk.blue('ℹ'),


### PR DESCRIPTION
Replace the `VSCODE_PID` check with a check for `xterm-256color`. This extends support beyond VS Code to other tools built on top of [xterm.js](https://github.com/xtermjs/xterm.js).

For my use case, this adds support in Hyper while maintaining support in VS Code. I've also tested this change in PowerShell and CMD where the fallbacks continue to be used. 

OS: Windows 10