### PR TITLE
Require Node.js 10 and upgrade chalk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
+  - '14'
   - '12'
   - '10'
-  - '8'

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=8"
+		"node": ">=10"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"
@@ -38,13 +38,13 @@
 		"stdout"
 	],
 	"dependencies": {
-		"chalk": "^2.4.2"
+		"chalk": "^4.0.0"
 	},
 	"devDependencies": {
-		"ava": "^1.4.1",
-		"strip-ansi": "^5.2.0",
-		"tsd": "^0.7.2",
-		"xo": "^0.24.0"
+		"ava": "^3.7.1",
+		"strip-ansi": "^6.0.0",
+		"tsd": "^0.11.0",
+		"xo": "^0.28.3"
 	},
 	"browser": "browser.js"
 }

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 'use strict';
-import test from 'ava';
-import stripAnsi from 'strip-ansi';
-import logSymbols from '.';
+const test = require('ava');
+const stripAnsi = require('strip-ansi');
+const logSymbols = require('.');
 
 for (const [key, value] of Object.entries(logSymbols)) {
 	console.log(value, key);


### PR DESCRIPTION
* add Node.js 14 to travis-ci
* update development dependencies

---

I attempted to update xo to 0.29.1 but this caused TypeScript errors:
```
  index.test-d.ts:4:1
  ✖  4:1   Unsafe call of an any typed value              @typescript-eslint/no-unsafe-call
  ✖  4:20  Unsafe member access .info on an any value     @typescript-eslint/no-unsafe-member-access
  ✖  5:1   Unsafe call of an any typed value              @typescript-eslint/no-unsafe-call
  ✖  5:20  Unsafe member access .success on an any value  @typescript-eslint/no-unsafe-member-access
  ✖  6:1   Unsafe call of an any typed value              @typescript-eslint/no-unsafe-call
  ✖  6:20  Unsafe member access .warning on an any value  @typescript-eslint/no-unsafe-member-access
  ✖  7:1   Unsafe call of an any typed value              @typescript-eslint/no-unsafe-call
  ✖  7:20  Unsafe member access .error on an any value    @typescript-eslint/no-unsafe-member-access
```

Odd note the rule names were not links to documentation, though my TypeScript abilities are very weak so I'm not sure I'd be able to fix this even with hints from the rules documentation.

ava produces a warning in node.js 14 but this doesn't seem to break the testing.  Someone has already opened a PR against ava to fix that warning.