### PR TITLE
feat: display fancy symbols on Windows Terminal

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 const chalk = require('chalk');
 
-const isSupported = process.platform !== 'win32' || process.env.CI || process.env.TERM === 'xterm-256color';
+const isSupported = process.platform !== 'win32' || process.env.CI || process.env.TERM === 'xterm-256color' || !!process.env.WT_SESSION;
 
 const main = {
 	info: chalk.blue('ℹ'),

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 const chalk = require('chalk');
 
-const isSupported = process.platform !== 'win32' || process.env.CI || process.env.TERM === 'xterm-256color' || !!process.env.WT_SESSION;
+const isSupported = process.platform !== 'win32' || process.env.CI || process.env.TERM === 'xterm-256color' || Boolean(process.env.WT_SESSION);
 
 const main = {
 	info: chalk.blue('ℹ'),


### PR DESCRIPTION
On `conhost.exe`, these characters were not supported. But on Windows Terminal, they are. The Windows Terminal adds the [`WT_SESSION`](https://github.com/microsoft/terminal/issues/840) environment variable, which allows to identify when it's used. Thanks to that, we can now display fancy figures on Windows.

This change updates the previous behavior by adding an additional check against the `WT_SESSION` environment variable, in order to allow these characters on the Windows Terminal.

![](https://i.imgur.com/W2qlHUI.png)