### PR TITLE
Use main symbols on Windows when using Alacritty terminal

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 const chalk = require('chalk');
 
-const isSupported = process.platform !== 'win32' || process.env.CI || process.env.TERM === 'xterm-256color';
+const isSupported = process.platform !== 'win32' || process.env.CI || process.env.TERM === 'xterm-256color' || (process.platform === 'win32' && process.env.TERM === 'alacritty');
 
 const main = {
 	info: chalk.blue('ℹ'),


### PR DESCRIPTION
on Windows, the main symbols can successfully be used without the terminal defaulting to a replacement character if the `$TERM` environment variable is set to `alacritty`:

![code used to test support](https://user-images.githubusercontent.com/12767408/111057226-99e7b180-843a-11eb-80f8-5054ddbf75e8.png)
![result of the test as seen in Alacritty](https://user-images.githubusercontent.com/12767408/111057234-ad931800-843a-11eb-9e04-1466edea5287.png)

(the check mark *appears* too close to the text, but i think that's because of my choice of terminal font, or the difference in font rendering between Windows and other operating systems)