### PR TITLE
add exports.types entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 	},
 	"type": "module",
 	"exports": {
+		"types": "./index.d.ts",
 		"node": "./index.js",
 		"default": "./browser.js"
 	},


### PR DESCRIPTION
type index.d.ts not resolved with `moduleResoltion: Bundler`.

```
"target": "ESNext",
"module": "ESNext",
"moduleResolution": "Bundler",
```

![image](https://github.com/sindresorhus/log-symbols/assets/4067115/b0ae1d78-fd25-495f-8c81-416939f3bb81)

```txt
Could not find a declaration file for module 'log-symbols'. '/Users/magicdawn/projects/vbox/node_modules/.pnpm/log-symbols@5.1.0/node_modules/log-symbols/browser.js' implicitly has an 'any' type.
  There are types at '/Users/magicdawn/projects/vbox/node_modules/log-symbols/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'log-symbols' library may need to update its package.json or typings.ts(7016)
```

add `exports.types` to package.json entry fix this.
