### PR TITLE
Replace error symbol with heavy multiplication x

### DIFF
--- a/symbols.js
+++ b/symbols.js
@@ -11,4 +11,4 @@ const _isUnicodeSupported = isUnicodeSupported();
 export const info = blue(_isUnicodeSupported ? 'ℹ' : 'i');
 export const success = green(_isUnicodeSupported ? '✔' : '√');
 export const warning = yellow(_isUnicodeSupported ? '⚠' : '‼');
-export const error = red(_isUnicodeSupported ? '✖️' : '×');
+export const error = red(_isUnicodeSupported ? '✖' : '×');

--- a/test.js
+++ b/test.js
@@ -2,12 +2,26 @@ import test from 'ava';
 import stripAnsi from 'strip-ansi';
 import logSymbols from './index.js';
 
-for (const [key, value] of Object.entries(logSymbols)) {
-	console.log(value, key);
-}
-
-console.log('');
+const symbols = Object.entries(logSymbols)
+	.map(([key, value]) => `${value} ${key}`)
+	.join('\n');
 
 test('returns log symbols', t => {
+	t.true(stripAnsi(logSymbols.info) === 'ℹ' || stripAnsi(logSymbols.info) === 'i');
 	t.true(stripAnsi(logSymbols.success) === '✔' || stripAnsi(logSymbols.success) === '√');
+	t.true(stripAnsi(logSymbols.warning) === '⚠' || stripAnsi(logSymbols.warning) === '‼');
+	t.true(stripAnsi(logSymbols.error) === '✖' || stripAnsi(logSymbols.error) === '×');
+	t.log(symbols);
+});
+
+test('confirms Unicode code point for log symbols', t => {
+	const infoCodePoint = stripAnsi(logSymbols.info).codePointAt(0);
+	const successCodePoint = stripAnsi(logSymbols.success).codePointAt(0);
+	const warningCodePoint = stripAnsi(logSymbols.warning).codePointAt(0);
+	const errorCodePoint = stripAnsi(logSymbols.error).codePointAt(0);
+
+	t.true(infoCodePoint === 8505 || infoCodePoint === 105);
+	t.true(successCodePoint === 10_004 || successCodePoint === 8730);
+	t.true(warningCodePoint === 9888 || warningCodePoint === 8252);
+	t.true(errorCodePoint === 10_006 || errorCodePoint === 215);
 });


### PR DESCRIPTION
Replacing the × symbol 

The × symbol is not shown in red and in an odd size, at least at my environment.

**Environment:**
node v22.12.0
npm 10.9.0
macOS 14.6.1

**Before:**
<img width="457" alt="Screenshot 2025-01-07 at 23 55 12" src="https://github.com/user-attachments/assets/3502c84e-051d-466e-93f1-d68dc6fbf284" />

**After:**
<img width="457" alt="Screenshot 2025-01-07 at 23 53 31" src="https://github.com/user-attachments/assets/359d127e-635d-4052-a332-501111ebae80" />